### PR TITLE
Fix #2 - Adding rh-nodejs8 to package to be installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM centos/s2i-base-centos7:latest
 # Install additional common utilities.
 
 RUN HOME=/root && \
-    INSTALL_PKGS="nano python-devel" && \
+    INSTALL_PKGS="nano python-devel rh-nodejs8" && \
     yum install -y centos-release-scl && \
     yum -y --setopt=tsflags=nodocs install --enablerepo=centosplus $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \


### PR DESCRIPTION
The image is not building due dependency problems with package `rh-nodejs8` which is not installed in the base image. This was tested on OCP 3.11, 3.9 and local builds with `buildah`. This patch fixes the problem described on issue #2.