### PR TITLE
updated nodejs to 10 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN HOME=/opt/workshop && \
 
 RUN HOME=/opt/workshop && \
     cd /opt/workshop && \
-    source scl_source enable rh-nodejs8 && \
+    source scl_source enable rh-nodejs10 && \
     npm install http-proxy
 
 RUN HOME=/opt/workshop && \


### PR DESCRIPTION
nodejs8 was failing during the build: 
Can't read /etc/scl/conf/rh-nodejs8, rh-nodejs8 is probably not installed.
so changing to 10 it worked.